### PR TITLE
add endpoint for whitelisting address

### DIFF
--- a/src/domain/account/whitelist/create.js
+++ b/src/domain/account/whitelist/create.js
@@ -1,0 +1,19 @@
+const { Whitelist } = require('./../../../infra/database/models');
+
+async function create({ address, tag }) {
+  if (!tag) {
+    tag = 'personal_invite';
+  }
+  const createdWhitelist = await Whitelist.updateOne(
+    { invokerAddress: address.toLowerCase() },
+    {
+      $set: {
+        tag,
+      },
+    },
+    { upsert: true },
+  );
+  return createdWhitelist.acknowledged;
+}
+
+module.exports = create;

--- a/src/domain/account/whitelist/index.js
+++ b/src/domain/account/whitelist/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   hasDeployedPortal: require('./hasDeployedPortal'),
   hasReferralCode: require('./hasReferralCode'),
+  create: require('./create'),
 };

--- a/src/domain/account/whitelist/index.js
+++ b/src/domain/account/whitelist/index.js
@@ -2,4 +2,5 @@ module.exports = {
   hasDeployedPortal: require('./hasDeployedPortal'),
   hasReferralCode: require('./hasReferralCode'),
   create: require('./create'),
+  remove: require('./remove'),
 };

--- a/src/domain/account/whitelist/remove.js
+++ b/src/domain/account/whitelist/remove.js
@@ -1,0 +1,18 @@
+const _errorHandler = require('../../../infra/errorHandler');
+const { Whitelist } = require('./../../../infra/database/models');
+
+async function remove(address) {
+  const whitelist = await Whitelist.findOne({
+    invokerAddress: address.toLowerCase(),
+  });
+  if (!whitelist) {
+    return _errorHandler.throwError({
+      code: 404,
+      message: 'address not found',
+    });
+  }
+  await whitelist.delete();
+  return true;
+}
+
+module.exports = remove;

--- a/src/interface/account/createWhitelist.js
+++ b/src/interface/account/createWhitelist.js
@@ -1,0 +1,18 @@
+const Whitelist = require('../../domain/account/whitelist');
+const { validator } = require('../middleware');
+const { Joi, validate } = validator;
+
+const createWhitelistValidation = {
+  body: Joi.object({
+    address: Joi.string().required(),
+    tag: Joi.string().invalid('admin').optional(),
+  }),
+};
+
+async function createWhitelist(req, res) {
+  const { address, tag } = req.body;
+  const isWhitelisted = await Whitelist.create({ address, tag });
+  res.json({ isWhitelisted });
+}
+
+module.exports = [validate(createWhitelistValidation), createWhitelist];

--- a/src/interface/account/index.js
+++ b/src/interface/account/index.js
@@ -2,11 +2,7 @@ const express = require('express');
 
 const router = express.Router();
 
-const {
-  asyncHandler,
-  asyncHandlerArray,
-} = require('../../infra/asyncHandler');
-
+const { asyncHandler, asyncHandlerArray } = require('../../infra/asyncHandler');
 
 const getNftsByAccount = require('./getNftsByAccount');
 const getTokensByAccount = require('./getTokensByAccount');
@@ -18,7 +14,9 @@ const {
   canViewAccount,
   canRegisterMember,
   canCheckWhitelist,
+  canWhitelistOthers,
 } = require('../middleware');
+const createWhitelist = require('./createWhitelist');
 
 router.get(
   '/nfts',
@@ -36,6 +34,12 @@ router.post(
   '/register',
   asyncHandler(canRegisterMember),
   asyncHandlerArray(registerMember),
+);
+
+router.post(
+  '/whitelist/create',
+  asyncHandler(canWhitelistOthers),
+  asyncHandlerArray(createWhitelist),
 );
 
 router.get(

--- a/src/interface/account/index.js
+++ b/src/interface/account/index.js
@@ -17,6 +17,7 @@ const {
   canWhitelistOthers,
 } = require('../middleware');
 const createWhitelist = require('./createWhitelist');
+const removeWhitelist = require('./removeWhitelist');
 
 router.get(
   '/nfts',
@@ -40,6 +41,12 @@ router.post(
   '/whitelist/create',
   asyncHandler(canWhitelistOthers),
   asyncHandlerArray(createWhitelist),
+);
+
+router.delete(
+  '/whitelist/remove',
+  asyncHandler(canWhitelistOthers),
+  asyncHandlerArray(removeWhitelist),
 );
 
 router.get(

--- a/src/interface/account/removeWhitelist.js
+++ b/src/interface/account/removeWhitelist.js
@@ -1,0 +1,17 @@
+const Whitelist = require('../../domain/account/whitelist');
+const { validator } = require('../middleware');
+const { Joi, validate } = validator;
+
+const removeWhitelistValidation = {
+  query: Joi.object({
+    address: Joi.string().required(),
+  }),
+};
+
+async function createWhitelist(req, res) {
+  const { address } = req.query;
+  const isRemoved = await Whitelist.remove(address);
+  res.json({ isRemoved });
+}
+
+module.exports = [validate(removeWhitelistValidation), createWhitelist];

--- a/src/interface/middleware/canWhitelistOthers.js
+++ b/src/interface/middleware/canWhitelistOthers.js
@@ -1,0 +1,26 @@
+const { Whitelist } = require('../../infra/database/models');
+const _errorHandler = require('../../infra/errorHandler');
+
+async function canWhitelistOthers(req, res, next) {
+  const { invokerAddress } = req;
+  if (!req.isAuthenticated) {
+    let statusCode = 403;
+    if (!invokerAddress) statusCode = 401;
+    return _errorHandler.throwError({
+      code: statusCode,
+      message: `${invokerAddress} cannot whitelist others.`,
+    });
+  }
+  const account = await Whitelist.findOne({
+    invokerAddress: invokerAddress.toLowerCase(),
+  });
+  if (!account || account.tag !== 'admin') {
+    return _errorHandler.throwError({
+      code: 403,
+      message: `${invokerAddress} cannot whitelist others.`,
+    });
+  }
+  next();
+}
+
+module.exports = canWhitelistOthers;

--- a/src/interface/middleware/index.js
+++ b/src/interface/middleware/index.js
@@ -7,4 +7,5 @@ module.exports = {
   canCheckWhitelist: require('./canCheckWhitelist'),
   errorHandler: require('./errorHandler'),
   validator: require('./validator'),
+  canWhitelistOthers: require('./canWhitelistOthers'),
 };


### PR DESCRIPTION
This PR introduces 2 endpoints to create and remove whitelists.
POST `/account/whitelist/create` 
DELETE `/account/whitelist/remove`
It allows only the addresses with tag "admin" to add or delete whitelists.